### PR TITLE
More "Grunt-ish" tasks trigger

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var grunt = require('grunt')
 var makeOptions = function(options) {
     baseOptions = {
         base: null,
-        prefix: 'grunt-'
+        prefix: 'grunt-',
+        verbose: false
     }
 
     if(options) {
@@ -37,8 +38,14 @@ var getTasks = module.exports.tasks = function(options) {
         finalTasks = {}
 
     for(var name in gruntTasks) {
-        var task = gruntTasks[name]
-        finalTasks[opt.prefix + name] = task.fn
+        finalTasks[opt.prefix + name] = (function (taskName) {
+            return function() {
+                opt.verbose && console.log('Runnin Grunt "'+taskName+'" task...')
+                grunt.tasks([taskName], {}, function() {
+                    opt.verbose && grunt.log.ok('Done running Grunt "'+taskName+'" task.')
+                })
+            }
+        })(name) //ensure task name proper scoping in the loop
     }
 
     return finalTasks;


### PR DESCRIPTION
Hello !

Thank you for this "Grunt to gulp" transition plugin ! :-)

I have problems with the current implementation, though : the Grunt tasks are async, but we have no way to wait for a Grunt task completion with the current way of triggering Grunt tasks.
With this tiny fix, we are sure that the triggered Grunt task can be completed before yielding to the next gulp instruction. This avoid having to hack with the hidden "grunt.task._tasks.fn" functions, too.

I tried to keep your coding style, without ";" at ends of lines ;-)
