### PR TITLE
Update grunt dependency to ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt"
   ],
   "dependencies": {
-    "grunt": "^0.4.5"
+    "grunt": "^1.0.1"
   },
   "devDependencies": {
     "gulp-mocha": "^2.1.3",


### PR DESCRIPTION
Fixes some warnings about deprecations. Tests pass like before.